### PR TITLE
Button styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,11 @@
+// External libraries
+@import "bootstrap";
+@import "font-awesome";
+
 // Graphical variables
 @import "config/fonts";
 @import "config/colors";
 @import "config/bootstrap_variables";
-
-// External libraries
-@import "bootstrap";
-@import "font-awesome";
 
 // Your CSS partials
 @import "components/index";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -13,6 +13,7 @@
 
 a {
   color: $accent;
+  font-size: 2.4rem;
 }
 
 .dropdown-item {

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -28,3 +28,39 @@ $input-border-radius: 20px;
 $input-bg: $secondary;
 $component-active-bg: $accent;
 $custom-checkbox-indicator-indeterminate-bg: $accent;
+
+// button overrides
+.btn {
+  font-size: 2rem;
+  border-radius: 2rem;
+}
+
+.btn-outline-primary {
+  background-color: $primary;
+  border-color: $info;
+  color: $body-color;
+}
+
+.btn-primary {
+  background-color: $info;
+  border-color: $info;
+  color: $primary;
+}
+
+.btn:hover {
+  background-color: inherit;
+  color: inherit;
+  border-color: inherit;
+}
+
+.btn-outline-primary:hover {
+  background-color: $primary;
+  border-color: $info;
+  color: $body-color;
+}
+
+.btn-primary:hover {
+  background-color: $info;
+  border-color: $info;
+  color: $primary;
+}

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -18,12 +18,33 @@ $headers-font: 'Fugaz One', serif;
 //        font-url('FontFile.ttf') format('truetype')
 // }
 // $my-font: "Font Name";
+
 h1, h2 {
   font-family: $headers-font;
 }
 
+h1 {
+  font-size: 3.6rem;
+}
+
+h2 {
+  font-size: 2.4rem;
+}
+
 h3, h4, p {
   font-family: $body-font;
+}
+
+h3 {
+  font-size: 2.4rem;
+}
+
+h4 {
+  font-size: 2.0rem;
+}
+
+p {
+  font-size: 1.8rem;
 }
 
 .text-search {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,7 @@
     <div>
       <% if user_signed_in? %>
         <%= link_to chats_path do %>
-          <i class="fa-regular fa-paper-plane nav-link fa-2xl pe-4"></i>
+          <i class="fa-regular fa-paper-plane nav-link fa-l pe-4"></i>
         <% end %>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <%= image_tag current_user.avatar_url, class: "avatar" %>
@@ -33,4 +33,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
 Button styling required reordering imports of stylesheets - bootstrap overrides had been above bootstrap import and thus actions like <strong> were being overridden by bootstrap. Reordering the imports showed font sizing to be incorrect, so latest commit of this branch has font sizing correction for h1 - h4, p and a elements. Behavior has been checked on existing pages but raise issues if the sizing doesn't render well.