### PR TITLE
Dash element spacing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@ a {
   top:50px;
   width:100%;
   z-index: 1020;
+  justify-content: flex-start;
 }
 
 .sticky-class-2 {
@@ -52,5 +53,3 @@ a {
 .mapboxgl-render{
   visibility: none;
 }
-
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,6 +44,7 @@ a {
 .scrollable {
   overflow: scroll;
   height: 70vh;
+  min-height: 93rem;
 }
 
 .banner-index{

--- a/app/assets/stylesheets/components/_user_summary.scss
+++ b/app/assets/stylesheets/components/_user_summary.scss
@@ -6,6 +6,10 @@
   border: none;
 }
 
+.card-dash {
+  height: 30rem;
+}
+
 .card-upper {
   height: 30vh;
 }

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -56,7 +56,3 @@ p {
   margin: 2vh 0;
   min-height: 7rem;
 }
-
-.page-content {
-  min-height: 93rem;
-}

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -54,4 +54,9 @@ p {
 .title-center {
   text-align: center;
   margin: 2vh 0;
+  min-height: 7rem;
+}
+
+.page-content {
+  min-height: 93rem;
 }

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,8 +1,8 @@
-<div class="title-center background-primary pt-4 py-3 m-0 mt-3 sticky-class sticky-class-2">
+<div class="title-center background-secondary pt-4 py-3 m-0 sticky-class sticky-class-2">
   <%= link_to "Profile", profile_path(current_user), class: "btn btn-outline-primary col-4 me-5" %>
   <%= link_to "Jams", dashboard_path, class: "btn btn-primary col-4 me-5" %>
 </div>
-<div class="scrollable">
+<div class="scrollable page-content">
   <%= render 'shared/user_dash_card', user: @user %>
   <% if @jams.length > 0 %>
     <% @months.each do |month| %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,8 +1,8 @@
 <div class="title-center background-secondary pt-4 py-3 m-0 sticky-class sticky-class-2">
-  <%= link_to "Profile", profile_path(current_user), class: "btn btn-outline-primary col-4 me-5" %>
-  <%= link_to "Jams", dashboard_path, class: "btn btn-primary col-4 me-5" %>
+  <%= link_to "Profile", profile_path(current_user), class: "btn btn-outline-primary col-4 mx-3" %>
+  <%= link_to "Jams", dashboard_path, class: "btn btn-primary col-4 mx-3" %>
 </div>
-<div class="scrollable page-content">
+<div class="scrollable">
   <%= render 'shared/user_dash_card', user: @user %>
   <% if @jams.length > 0 %>
     <% @months.each do |month| %>

--- a/app/views/shared/_user_dash_card.html.erb
+++ b/app/views/shared/_user_dash_card.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="card my-2">
+  <div class="card card-dash my-2">
     <div class="card-upper">
       <div class="card-img-top" style="background-image: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255,1)), url('<%= image_path user.banner_url %>');">
       </div>


### PR DESCRIPTION
dashboard body elements were inheriting justify:space-between. implemented an override within the scrollable class to set minimum view height for pages with less than a full screen's worth of content. 
buttons to swap views between current_user profile and scheduled jams were given correct background color, improved x spacing.